### PR TITLE
Refactor storage from JSON to SQLite and ensure data migration

### DIFF
--- a/lifestealz.iml
+++ b/lifestealz.iml
@@ -5,6 +5,7 @@
       <configuration>
         <autoDetectTypes>
           <platformType>PAPER</platformType>
+          <platformType>ADVENTURE</platformType>
         </autoDetectTypes>
         <projectReimportVersion>1</projectReimportVersion>
       </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.strassburger</groupId>
     <artifactId>lifestealz</artifactId>
-    <version>1.0.11</version>
+    <version>1.0.12</version>
     <packaging>jar</packaging>
 
     <name>lifestealz</name>
@@ -160,6 +160,11 @@
             <artifactId>kotlin-test</artifactId>
             <version>${kotlin.version}</version>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.xerial</groupId>
+            <artifactId>sqlite-jdbc</artifactId>
+            <version>3.45.3.0</version>
         </dependency>
     </dependencies>
 </project>

--- a/src/main/java/org/strassburger/lifestealz/Lifestealz.kt
+++ b/src/main/java/org/strassburger/lifestealz/Lifestealz.kt
@@ -129,6 +129,8 @@ class Lifestealz : JavaPlugin() {
         registerEvents()
 
         initializeConfig()
+        ManagePlayerdata.initializeDatabase()
+        DataMigration.migrateData()
 
         registerHeartRecipe()
         registerReviveRecipe()

--- a/src/main/java/org/strassburger/lifestealz/util/DataMigration.kt
+++ b/src/main/java/org/strassburger/lifestealz/util/DataMigration.kt
@@ -1,0 +1,59 @@
+package org.strassburger.lifestealz.util
+
+import com.google.gson.Gson
+import org.strassburger.lifestealz.Lifestealz
+import org.strassburger.lifestealz.util.data.PlayerData
+import java.io.File
+import java.io.FileReader
+import java.sql.DriverManager
+import java.sql.PreparedStatement
+
+object DataMigration {
+
+    // This object is used to migrate data from the old storage (JSON) to the new storage (SQLite)
+    // to avoid data loss when the plugin is updated. Can be removed after the first update.
+
+    fun migrateData() {
+        val plugin = Lifestealz.instance
+
+        val userDataFolder = File(plugin.dataFolder, "userData")
+        val jsonFiles = userDataFolder.listFiles { dir, name -> name.endsWith(".json") }
+        if (jsonFiles == null || jsonFiles.isEmpty()) {
+            plugin.logger.info("No JSON files found. Skipping data migration.")
+            return
+        }
+
+        val dbPath = File(plugin.dataFolder, "userData.db").path
+        try {
+            DriverManager.getConnection("jdbc:sqlite:$dbPath").use { conn ->
+                val sql = "INSERT OR REPLACE INTO hearts (uuid, name, maxhp, hasbeenRevived, craftedHearts, craftedRevives, killedOtherPlayers) VALUES (?, ?, ?, ?, ?, ?, ?)"
+                val pstmt: PreparedStatement = conn.prepareStatement(sql)
+                val gson = Gson()
+
+                jsonFiles.forEach { file ->
+                    val playerData = gson.fromJson(FileReader(file), PlayerData::class.java)
+                    pstmt.setString(1, playerData.uuid)
+                    pstmt.setString(2, playerData.name)
+                    pstmt.setDouble(3, playerData.maxhp)
+                    pstmt.setInt(4, playerData.hasbeenRevived)
+                    pstmt.setInt(5, playerData.craftedHearts)
+                    pstmt.setInt(6, playerData.craftedRevives)
+                    pstmt.setInt(7, playerData.killedOtherPlayers)
+                    pstmt.executeUpdate()
+
+                    // Delete the JSON file after successful migration
+                    file.delete()
+                }
+                pstmt.close()
+
+                if (userDataFolder.listFiles().isNullOrEmpty()){
+                    // Delete the userData folder after successful migration
+                    userDataFolder.delete()
+                    plugin.logger.info("Data migration completed.")
+                }
+            }
+        } catch (e: Exception) {
+            plugin.logger.severe("Error during data migration: ${e.message}")
+        }
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,7 +1,7 @@
 name: LifeStealZ
 version: '${project.version}'
 main: org.strassburger.lifestealz.Lifestealz
-api-version: 1.20
+api-version: '1.20'
 author: Kartoffelchips
 website: https://modrinth.com/plugin/lifestealz
 description: A LifeSteal SMP plugin providing you all the features you need!


### PR DESCRIPTION
This commit transitions the player data storage system from JSON files to an SQLite database, improving data management and scalability. It includes a DataMigration class to handle existing data conversion, ensuring no data loss for users upgrading to this version.

Additionally, the pom.xml has been updated to modify the project version, and the plugin.yml file now specifies the `api-version` as '1.20' (enclosed in quotes) to address YAML interpretation issues with versioning & ensuring compatibility.

These changes are designed to enhance data integrity, facilitate future upgrades, and maintain compatibility with newer API versions.

---
- **Main Changes**:
  - Transitioned from JSON to SQLite for player data storage.
  - Added data migration strategy to preserve existing data.
- **Minor Changes**:
  - Updated project version in pom.xml.
  - Corrected `api-version` in plugin.yml to prevent YAML type interpretation errors.