### PR TITLE
Add configurable sound effect for heart usage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.strassburger</groupId>
     <artifactId>lifestealz</artifactId>
-    <version>1.0.13</version>
+    <version>1.0.14</version>
     <packaging>jar</packaging>
 
     <name>lifestealz</name>

--- a/src/main/java/org/strassburger/lifestealz/listener/PlayerInteractionListener.kt
+++ b/src/main/java/org/strassburger/lifestealz/listener/PlayerInteractionListener.kt
@@ -61,7 +61,13 @@ class PlayerInteractionListener : Listener {
                     ManagePlayerdata().manageHearts(player = player, amount = 2.0, direction = "inc")
                     player.maxHealth += 2.0
                     player.health += 2.0
-                    player.playSound(player.getLocation(), Sound.ENTITY_PLAYER_LEVELUP, 500.0f, 1.0f)
+
+                    if (Lifestealz.instance.config.getBoolean("heartuseSound.enabled")) {
+                        val sound = Sound.valueOf(Lifestealz.instance.config.getString("heartuseSound.sound")!!)
+                        val volume = Lifestealz.instance.config.getDouble("heartuseSound.volume").toFloat()
+                        val pitch = Lifestealz.instance.config.getDouble("heartuseSound.pitch").toFloat()
+                        player.playSound(player.location, sound, volume, pitch)
+                    }
 
                     val heartuseCommands = Lifestealz.instance.config.getStringList("heartuseCommands")
                     heartuseCommands.forEach {

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -71,6 +71,12 @@ eliminationCommands:
 heartuseCommands:
   # - "say &player& used a heart item"
 
+heartuseSound:
+  enabled: true
+  sound: ENTITY_PLAYER_LEVELUP # Find all sounds here: https://hub.spigotmc.org/javadocs/bukkit/org/bukkit/Sound.html
+  volume: 1.0
+  pitch: 1.0
+
 reviveuseCommands:
   # - "say &player& revived &target&"
 


### PR DESCRIPTION
This commit introduces a new configuration option to customize the sound effect played when a heart is consumed in the Lifestealz plugin. The `heartuseSound` configuration allows server administrators to enable or disable the sound effect, and to specify the sound, volume, and pitch according to their preference.

Configurable options added:
- `heartuseSound.enabled`: Toggle the feature on or off.
- `heartuseSound.sound`: Specify the type of sound (defaulting to ENTITY_PLAYER_LEVELUP).
- `heartuseSound.volume`: Set the volume of the sound effect.
- `heartuseSound.pitch`: Adjust the pitch of the sound effect.