### PR TITLE
fix: Prevent world whitelist message when using non-heart/revive items

### DIFF
--- a/dependency-reduced-pom.xml
+++ b/dependency-reduced-pom.xml
@@ -4,7 +4,7 @@
   <groupId>org.strassburger</groupId>
   <artifactId>LifeStealZ</artifactId>
   <name>LifeStealZ</name>
-  <version>1.1.8</version>
+  <version>1.1.9</version>
   <description>A LifeSteal SMP plugin providing you all the features you need!</description>
   <build>
     <resources>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.strassburger</groupId>
     <artifactId>LifeStealZ</artifactId>
-    <version>1.1.8</version>
+    <version>1.1.9</version>
     <packaging>jar</packaging>
 
     <name>LifeStealZ</name>

--- a/src/main/java/org/strassburger/lifestealz/listeners/InteractionListener.java
+++ b/src/main/java/org/strassburger/lifestealz/listeners/InteractionListener.java
@@ -17,6 +17,9 @@ import java.util.List;
 public class InteractionListener implements Listener {
     @EventHandler
     public void onPlayerInteraction(PlayerInteractEvent event) {
+        if (event.getItem() == null) return;
+        if (!CustomItemManager.isHeartItem(event.getItem()) && !CustomItemManager.isReviveItem(event.getItem())) return;
+
         Player player = event.getPlayer();
 
         boolean worldIsWhitelisted = LifeStealZ.getInstance().getConfig().getStringList("worlds").contains(player.getLocation().getWorld().getName());

--- a/src/main/java/org/strassburger/lifestealz/listeners/InteractionListener.java
+++ b/src/main/java/org/strassburger/lifestealz/listeners/InteractionListener.java
@@ -17,8 +17,9 @@ import java.util.List;
 public class InteractionListener implements Listener {
     @EventHandler
     public void onPlayerInteraction(PlayerInteractEvent event) {
-        if (event.getItem() == null) return;
-        if (!CustomItemManager.isHeartItem(event.getItem()) && !CustomItemManager.isReviveItem(event.getItem())) return;
+        ItemStack item = event.getItem();
+        if (item == null) return;
+        if (!CustomItemManager.isHeartItem(item) && !CustomItemManager.isReviveItem(item)) return;
 
         Player player = event.getPlayer();
 
@@ -39,9 +40,9 @@ public class InteractionListener implements Listener {
 
                 PlayerData playerData = LifeStealZ.getInstance().getPlayerDataStorage().load(player.getUniqueId());
 
-                ItemStack item = event.getItem().clone();
+                ItemStack itemClone = item.clone();
 
-                int savedHeartAmount = item.getItemMeta().getPersistentDataContainer().has(CustomItemManager.CUSTOM_HEART_VALUE_KEY, PersistentDataType.INTEGER) ? item.getItemMeta().getPersistentDataContainer().get(CustomItemManager.CUSTOM_HEART_VALUE_KEY, PersistentDataType.INTEGER) : 1;
+                int savedHeartAmount = itemClone.getItemMeta().getPersistentDataContainer().has(CustomItemManager.CUSTOM_HEART_VALUE_KEY, PersistentDataType.INTEGER) ? itemClone.getItemMeta().getPersistentDataContainer().get(CustomItemManager.CUSTOM_HEART_VALUE_KEY, PersistentDataType.INTEGER) : 1;
                 double heartsToAdd = savedHeartAmount * 2;
                 double newHearts = playerData.getMaxhp() + heartsToAdd;
 

--- a/src/main/java/org/strassburger/lifestealz/listeners/InteractionListener.java
+++ b/src/main/java/org/strassburger/lifestealz/listeners/InteractionListener.java
@@ -18,15 +18,12 @@ public class InteractionListener implements Listener {
     @EventHandler
     public void onPlayerInteraction(PlayerInteractEvent event) {
         ItemStack item = event.getItem();
-        if (item == null) return;
-        if (!CustomItemManager.isHeartItem(item) && !CustomItemManager.isReviveItem(item)) return;
-
         Player player = event.getPlayer();
 
         boolean worldIsWhitelisted = LifeStealZ.getInstance().getConfig().getStringList("worlds").contains(player.getLocation().getWorld().getName());
 
         if (event.getAction().isRightClick() && event.getItem() != null) {
-            if (!worldIsWhitelisted) {
+            if (!worldIsWhitelisted && (CustomItemManager.isHeartItem(event.getItem()) || CustomItemManager.isReviveItem(event.getItem()))) {
                 player.sendMessage(MessageUtils.getAndFormatMsg(false, "messages.worldNotWhitelisted", "&cThis world is not whitelisted for LifeStealZ!"));
                 return;
             }
@@ -40,9 +37,10 @@ public class InteractionListener implements Listener {
 
                 PlayerData playerData = LifeStealZ.getInstance().getPlayerDataStorage().load(player.getUniqueId());
 
-                ItemStack itemClone = item.clone();
+                ItemStack itemClone = event.getItem().clone();
 
-                int savedHeartAmount = itemClone.getItemMeta().getPersistentDataContainer().has(CustomItemManager.CUSTOM_HEART_VALUE_KEY, PersistentDataType.INTEGER) ? itemClone.getItemMeta().getPersistentDataContainer().get(CustomItemManager.CUSTOM_HEART_VALUE_KEY, PersistentDataType.INTEGER) : 1;
+                Integer savedHeartAmountInteger = itemClone.getItemMeta().getPersistentDataContainer().has(CustomItemManager.CUSTOM_HEART_VALUE_KEY, PersistentDataType.INTEGER) ? itemClone.getItemMeta().getPersistentDataContainer().get(CustomItemManager.CUSTOM_HEART_VALUE_KEY, PersistentDataType.INTEGER) : 1;
+                int savedHeartAmount = savedHeartAmountInteger != null ? savedHeartAmountInteger : 1;
                 double heartsToAdd = savedHeartAmount * 2;
                 double newHearts = playerData.getMaxhp() + heartsToAdd;
 


### PR DESCRIPTION
Fixed whitelist message when using non-heart/revive items by checking the Interaction item first.