### PR TITLE
Seperate option for drop-hearts on natural or player-kill death.

### DIFF
--- a/src/main/java/org/strassburger/lifestealz/listeners/PlayerDeathListener.java
+++ b/src/main/java/org/strassburger/lifestealz/listeners/PlayerDeathListener.java
@@ -55,8 +55,7 @@ public class PlayerDeathListener implements Listener {
             world.dropItemNaturally(player.getLocation(), CustomItemManager.createHeart());
         } else if (isDeathByPlayer) {
             handleKillerHeartGain(player, killer, world);
-        }
-        else if(plugin.getConfig().getBoolean("dropHeartsNatural")){
+        } else if (plugin.getConfig().getBoolean("dropHeartsNatural")) {
             world.dropItemNaturally(player.getLocation(), CustomItemManager.createHeart());
         }
 
@@ -76,7 +75,6 @@ public class PlayerDeathListener implements Listener {
         final List<String> elimCommands = plugin.getConfig().getStringList("eliminationCommands");
         final boolean disableBanOnElimination = plugin.getConfig().getBoolean("disablePlayerBanOnElimination");
         final boolean announceElimination = plugin.getConfig().getBoolean("announceElimination");
-        final World world = player.getWorld();
 
         Bukkit.getScheduler().scheduleSyncDelayedTask(plugin, () -> {
             for (String command : elimCommands) {

--- a/src/main/java/org/strassburger/lifestealz/listeners/PlayerDeathListener.java
+++ b/src/main/java/org/strassburger/lifestealz/listeners/PlayerDeathListener.java
@@ -51,10 +51,13 @@ public class PlayerDeathListener implements Listener {
         final double minHearts = plugin.getConfig().getInt("minHearts") * 2;
 
         // Drop hearts or handle heart gain for the killer (if applicable)
-        if (plugin.getConfig().getBoolean("dropHearts")) {
+        if (isDeathByPlayer && plugin.getConfig().getBoolean("dropHeartsPlayer")) {
             world.dropItemNaturally(player.getLocation(), CustomItemManager.createHeart());
         } else if (isDeathByPlayer) {
             handleKillerHeartGain(player, killer, world);
+        }
+        else if(plugin.getConfig().getBoolean("dropHeartsNatural")){
+            world.dropItemNaturally(player.getLocation(), CustomItemManager.createHeart());
         }
 
         // Check for elimination

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -60,8 +60,10 @@ heartItem: "defaultheart"
 
 # === HEART BEHAVIOR SETTINGS ===
 
-# If hearts should be dropped instead of directly added to the killer
-dropHearts: false
+# If hearts should be dropped when killed by player
+dropHeartsPlayer: false
+# If hearts should be dropped when killed naturally
+dropHeartsNatural: true
 # If a heart should be dropped, when the killer already has the max amount of hearts
 dropHeartsIfMax: true
 # If a player should lose a heart, when dying to hostile mobs or falldamage, lava, etc


### PR DESCRIPTION
Added more options for the user to configure the drop-heart mechanics for natural and player-kill deaths.

### Old Config : 
```
dropHearts: true | false
```
----
### New Config : 
```
dropHeartsPlayer: true | false

dropHeartsNatural: true | false
```
