### PR TITLE
Handle trailing whitespace caused by empty prefix edgecase

### DIFF
--- a/src/main/java/org/strassburger/lifestealz/util/MessageUtils.java
+++ b/src/main/java/org/strassburger/lifestealz/util/MessageUtils.java
@@ -73,9 +73,7 @@ public final class MessageUtils {
         MiniMessage mm = MiniMessage.miniMessage();
         String msg = "<!i>" + LifeStealZ.getInstance().getLanguageManager().getString(path, fallback);
         String prefix = LifeStealZ.getInstance().getLanguageManager().getString("prefix", "&8[&cLifeStealZ&8]");
-        if (addPrefix) {
-            msg = prefix + " " + msg;
-        }
+        msg = (!prefix.isEmpty() && addPrefix) ? prefix + " " + msg : msg;
 
         for (Replaceable replaceable : replaceables) {
             msg = msg.replace(replaceable.getPlaceholder(), replaceable.getValue());


### PR DESCRIPTION
If `prefix` amongst any of the language files was an empty string, all messages would bare a trailing whitespace:
```yml
prefix: ""
...
reloadMsg: "&6[&e&lLifesteal&r&6] &7Successfully reloaded the plugin."
```
![image](https://github.com/user-attachments/assets/e943e8e3-13fa-453e-b7dd-f1f484930615)

This was due to an empty string being concatenated between the prefix, and message text, given a circumstance where prefix was empty, an empty string would still be provided. Can't believe Jan Straßburger could make such a silly mistake while programming, anyhow...