### PR TITLE
fix some spelling and stuff

### DIFF
--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -26,16 +26,16 @@ lang: "en-US"
 
 # === HEART SETTINGS ===
 
-# The amount of hearts a player has, when joining for the first time
+# The amount of hearts a player has when joining for the first time
 startHearts: 10
 # The maximal amount of hearts, a player can have
 # You can also set a per player limit using the lifestealz.maxhearts.[amount] permission or a per item limit in the items.yml file
 maxHearts: 20
-# The amount of hp a player should have after getting reived
+# The amount of hp a player should have after getting revived
 reviveHearts: 1
-# The amount of hearts the killer should gain and the victim should loose
+# The amount of hearts the killer should gain and the victim should lose
 heartsPerKill: 1
-# The amount of hearts a player should loose, when dying naturally
+# The amount of hearts a player should lose when dying naturally
 heartsPerNaturalDeath: 1
 # The minimal amount of hearts. If a player gets to this amount of hearts, they will be eliminated.
 # PLEASE ONLY CHANGE IF YOU KNOW WHAT YOU ARE DOING!
@@ -47,7 +47,7 @@ enforceMaxHeartsOnAdminCommands: false
 heartItem:
   # This item will be used for anything that is not listed below (mostly legacy)
   default: "defaultheart"
-  # This item will be given, when a user withdraws a heart
+  # This item will be given when a user withdraws a heart
   withdraw: "defaultheart"
   # This item will be dropped when a player is killed by another player and "dropHeartsPlayer" is enabled
   kill: "defaultheart"


### PR DESCRIPTION
Noticed a couple of unneeded commas and some minor spelling stuff toward the start of the config when I was using it. Hopefully, this should help with clarity.

Changed `loose` to `lose`
Changed `reived` to `revived`
Removed redundant commas