### PR TITLE
Grammar changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ antiAlt:
   preventKill: false
   # If a message should be sent to the player, when an alt kill attempt is detected
   sendMessage: false
-  # Add custom comamnds, to be executed when a possible alt kill attempt is detected
+  # Add custom commands, to be executed when a possible alt kill attempt is detected
   # You can use &player& to insert the player name (commands are executed for both players)
   commands:
   # - "say Please don't kill alts"

--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ gracePeriod:
   damageToPlayers: false
   # Should a player be able to use hearts during the grace period
   useHearts: false
-  # Should a player be able to loose hearts during the grace period (if set to false, the killer will also not gain a heart)
+  # Should a player be able to lose hearts during the grace period (if set to false, the killer will also not gain a heart)
   looseHearts: false
   # Should a player be able to gain hearts during the grace period
   gainHearts: false

--- a/src/main/java/com/zetaplugins/lifestealz/commands/MainCommand/subcommands/HeartsSubCommand.java
+++ b/src/main/java/com/zetaplugins/lifestealz/commands/MainCommand/subcommands/HeartsSubCommand.java
@@ -71,9 +71,9 @@ public final class HeartsSubCommand implements SubCommand {
             return false;
         }
 
-        int amount = Integer.parseInt(args[3]);
+        int numHearts = Integer.parseInt(args[3]);
 
-        if (amount < 0) {
+        if (numHearts < 0) {
             throwUsageError(sender, getUsage());
             return false;
         }
@@ -95,7 +95,7 @@ public final class HeartsSubCommand implements SubCommand {
             assert targetPlayer != null;
             PlayerData targetPlayerData = plugin.getStorage().load(targetPlayer.getUniqueId());
 
-            double maxAllowedHearts = config.getInt("maxHearts") * 2;
+            double maxAllowedHearts = config.getInt("maxHearts");
             Player targetOnlinePlayer = targetPlayer.getPlayer();
             if (targetOnlinePlayer != null)
                 maxAllowedHearts = MaxHeartsManager.getMaxHearts(targetOnlinePlayer, config);
@@ -104,19 +104,19 @@ public final class HeartsSubCommand implements SubCommand {
                 case "add": {
                     if (
                             config.getBoolean("enforceMaxHeartsOnAdminCommands")
-                            && targetPlayerData.getMaxHealth() + (amount * 2) > maxAllowedHearts
+                            && targetPlayerData.getMaxHealth() / 2 + numHearts > maxAllowedHearts
                     ) {
                         sendHeartLimitReachedMessage(sender, maxAllowedHearts);
                         return false;
                     }
 
-                    targetPlayerData.setMaxHealth(targetPlayerData.getMaxHealth() + (amount * 2));
+                    targetPlayerData.setMaxHealth(targetPlayerData.getMaxHealth() + (numHearts * 2));
                     storage.save(targetPlayerData);
                     if (targetPlayer instanceof Player) LifeStealZ.setMaxHealth((Player) targetPlayer, targetPlayerData.getMaxHealth());
                     break;
                 }
                 case "set": {
-                    if (amount == 0) {
+                    if (numHearts == 0) {
                         sender.sendMessage(MessageUtils.getAndFormatMsg(
                                 false,
                                 "connotSetHeartsBelowOrToZero",
@@ -125,18 +125,18 @@ public final class HeartsSubCommand implements SubCommand {
                         return false;
                     }
 
-                    if (config.getBoolean("enforceMaxHeartsOnAdminCommands") && amount * 2 > maxAllowedHearts) {
+                    if (config.getBoolean("enforceMaxHeartsOnAdminCommands") && numHearts > maxAllowedHearts) {
                         sendHeartLimitReachedMessage(sender, maxAllowedHearts);
                         return false;
                     }
 
-                    targetPlayerData.setMaxHealth(amount * 2);
+                    targetPlayerData.setMaxHealth(numHearts * 2);
                     storage.save(targetPlayerData);
                     if (targetPlayer instanceof Player) LifeStealZ.setMaxHealth((Player) targetPlayer, targetPlayerData.getMaxHealth());
                     break;
                 }
                 case "remove": {
-                    if ((targetPlayerData.getMaxHealth() / 2) - (double) amount <= 0) {
+                    if ((targetPlayerData.getMaxHealth() / 2) - (double) numHearts <= 0) {
                         sender.sendMessage(MessageUtils.getAndFormatMsg(
                                 false,
                                 "connotSetHeartsBelowOrToZero",
@@ -145,7 +145,7 @@ public final class HeartsSubCommand implements SubCommand {
                         return false;
                     }
 
-                    targetPlayerData.setMaxHealth(targetPlayerData.getMaxHealth() - (amount * 2));
+                    targetPlayerData.setMaxHealth(targetPlayerData.getMaxHealth() - (numHearts * 2));
                     storage.save(targetPlayerData);
                     if (targetPlayer instanceof Player) LifeStealZ.setMaxHealth((Player) targetPlayer, targetPlayerData.getMaxHealth());
                     break;
@@ -153,7 +153,7 @@ public final class HeartsSubCommand implements SubCommand {
             }
         }
 
-        sendConfirmMessage(sender, optionTwo, targetPlayers, amount);
+        sendConfirmMessage(sender, optionTwo, targetPlayers, numHearts);
         return true;
     }
 
@@ -210,7 +210,7 @@ public final class HeartsSubCommand implements SubCommand {
                 true,
                 "maxHeartLimitReached",
                 "&cYou already reached the limit of %limit% hearts!",
-                new MessageUtils.Replaceable("%limit%", (int)(maxHearts / 2) + ""));
+                new MessageUtils.Replaceable("%limit%", (int) maxHearts + ""));
         sender.sendMessage(maxHeartsMsg);
     }
 

--- a/src/main/java/com/zetaplugins/lifestealz/events/death/ZPlayerMaxHeartsReachedEvent.java
+++ b/src/main/java/com/zetaplugins/lifestealz/events/death/ZPlayerMaxHeartsReachedEvent.java
@@ -13,7 +13,7 @@ public class ZPlayerMaxHeartsReachedEvent extends ZPlayerDeathEventBase {
     private final Player killer;
     
     @Getter
-    private final double maxHeartsLimit;
+    private final double maxHeartLimit;
     
     @Getter @Setter
     private boolean shouldDropHeartsInstead;
@@ -24,13 +24,13 @@ public class ZPlayerMaxHeartsReachedEvent extends ZPlayerDeathEventBase {
     public ZPlayerMaxHeartsReachedEvent(PlayerDeathEvent originalEvent, Player killer, double maxHearts) {
         super(originalEvent);
         this.killer = killer;
-        this.maxHeartsLimit = maxHearts;
+        this.maxHeartLimit = maxHearts;
         this.shouldDropHeartsInstead = false;
         this.maxHeartsMessage = MessageUtils.getAndFormatMsg(
                 false,
                 "maxHeartLimitReached",
                 "&cYou already reached the limit of %limit% hearts!",
-                new MessageUtils.Replaceable("%limit%", String.valueOf((int) (maxHearts / 2)))
+                new MessageUtils.Replaceable("%limit%", String.valueOf((int) maxHearts))
         );
     }
 }

--- a/src/main/java/com/zetaplugins/lifestealz/events/death/ZPlayerNaturalDeathEvent.java
+++ b/src/main/java/com/zetaplugins/lifestealz/events/death/ZPlayerNaturalDeathEvent.java
@@ -7,7 +7,7 @@ import org.bukkit.event.entity.PlayerDeathEvent;
 
 public class ZPlayerNaturalDeathEvent extends ZPlayerDeathEventBase {
     @Getter @Setter
-    private double heartsToLose;
+    private double healthToLose;
 
     @Getter @Setter
     private boolean shouldDropHearts;
@@ -15,9 +15,9 @@ public class ZPlayerNaturalDeathEvent extends ZPlayerDeathEventBase {
     @Getter @Setter
     private String deathMessage;
 
-    public ZPlayerNaturalDeathEvent(PlayerDeathEvent originalEvent, double heartsToLose) {
+    public ZPlayerNaturalDeathEvent(PlayerDeathEvent originalEvent, double healthToLose) {
         super(originalEvent);
-        this.heartsToLose = heartsToLose;
+        this.healthToLose = healthToLose;
         this.shouldDropHearts = false;
         this.deathMessage = originalEvent.getDeathMessage();
     }

--- a/src/main/java/com/zetaplugins/lifestealz/events/death/ZPlayerPvPDeathEvent.java
+++ b/src/main/java/com/zetaplugins/lifestealz/events/death/ZPlayerPvPDeathEvent.java
@@ -11,10 +11,10 @@ public class ZPlayerPvPDeathEvent extends ZPlayerDeathEventBase {
     private final Player killer;
     
     @Getter @Setter
-    private double heartsToLose;
+    private double healthToLose;
     
     @Getter @Setter
-    private double heartsKillerGains;
+    private double healthKillerGains;
     
     @Getter @Setter
     private boolean shouldDropHearts;
@@ -25,11 +25,11 @@ public class ZPlayerPvPDeathEvent extends ZPlayerDeathEventBase {
     @Getter @Setter
     private String deathMessage;
 
-    public ZPlayerPvPDeathEvent(PlayerDeathEvent originalEvent, Player killer, double heartsToLose, double heartsKillerGains) {
+    public ZPlayerPvPDeathEvent(PlayerDeathEvent originalEvent, Player killer, double healthToLose, double healthKillerGains) {
         super(originalEvent);
         this.killer = killer;
-        this.heartsToLose = heartsToLose;
-        this.heartsKillerGains = heartsKillerGains;
+        this.healthToLose = healthToLose;
+        this.healthKillerGains = healthKillerGains;
         this.shouldDropHearts = false;
         this.killerShouldGainHearts = true;
         this.deathMessage = originalEvent.getDeathMessage();

--- a/src/main/java/com/zetaplugins/lifestealz/listeners/InteractionListener.java
+++ b/src/main/java/com/zetaplugins/lifestealz/listeners/InteractionListener.java
@@ -159,13 +159,13 @@ public final class InteractionListener implements Listener {
 
         Integer savedHeartAmountInteger = item.getItemMeta().getPersistentDataContainer().has(CustomItemManager.CUSTOM_HEART_VALUE_KEY, PersistentDataType.INTEGER) ? item.getItemMeta().getPersistentDataContainer().get(CustomItemManager.CUSTOM_HEART_VALUE_KEY, PersistentDataType.INTEGER) : 1;
         int savedHeartAmount = savedHeartAmountInteger != null ? savedHeartAmountInteger : 1;
-        double heartsToAdd = savedHeartAmount * 2;
-        double newHearts = playerData.getMaxHealth() + heartsToAdd;
+        double healthToAdd = savedHeartAmount * 2;
+        double newHealth = playerData.getMaxHealth() + healthToAdd;
 
         final double maxHearts = MaxHeartsManager.getMaxHearts(player, plugin.getConfig());
 
-        if (newHearts > maxHearts) {
-            player.sendMessage(MessageUtils.getAndFormatMsg(false, "maxHeartLimitReached", "&cYou already reached the limit of %limit% hearts!", new MessageUtils.Replaceable("%limit%", Integer.toString((int) maxHearts / 2))));
+        if (newHealth > maxHearts * 2) {
+            player.sendMessage(MessageUtils.getAndFormatMsg(false, "maxHeartLimitReached", "&cYou already reached the limit of %limit% hearts!", new MessageUtils.Replaceable("%limit%", Integer.toString((int) maxHearts))));
             return;
         }
 
@@ -185,10 +185,10 @@ public final class InteractionListener implements Listener {
             updateItemInHand(player, item, 40);
         }
 
-        playerData.setMaxHealth(newHearts);
+        playerData.setMaxHealth(newHealth);
         plugin.getStorage().save(playerData);
-        LifeStealZ.setMaxHealth(player, newHearts);
-        if (plugin.getConfig().getBoolean("healOnHeartUse")) player.setHealth(Math.min(player.getHealth() + heartsToAdd, newHearts));
+        LifeStealZ.setMaxHealth(player, newHealth);
+        if (plugin.getConfig().getBoolean("healOnHeartUse")) player.setHealth(Math.min(player.getHealth() + healthToAdd, newHealth));
 
         String customItemID = CustomItemManager.getCustomItemId(item);
         if (customItemID != null) {

--- a/src/main/java/com/zetaplugins/lifestealz/listeners/InteractionListener.java
+++ b/src/main/java/com/zetaplugins/lifestealz/listeners/InteractionListener.java
@@ -80,7 +80,7 @@ public final class InteractionListener implements Listener {
     /**
      * Checks if the event should be cancelled when a player interacts with a respawn anchor
      * @param event PlayerInteractEvent
-     * @return wether the event needs to be cancelled
+     * @return whether the event needs to be cancelled
      */
     private boolean shouldCancelRespawnAnchorUsage(PlayerInteractEvent event) {
         if (event.getAction() != Action.RIGHT_CLICK_BLOCK || !plugin.getConfig().getBoolean("preventRespawnAnchors")) {

--- a/src/main/java/com/zetaplugins/lifestealz/listeners/InventoryClickListener.java
+++ b/src/main/java/com/zetaplugins/lifestealz/listeners/InventoryClickListener.java
@@ -240,7 +240,7 @@ public final class InventoryClickListener implements Listener {
     }
 
     /**
-     * Modifes the data of the player being revived.
+     * Modifies the data of the player being revived.
      * @param data The PlayerData of the player being revived.
      */
     private void applyReviveData(PlayerData data) {

--- a/src/main/java/com/zetaplugins/lifestealz/listeners/PlayerDeathListener.java
+++ b/src/main/java/com/zetaplugins/lifestealz/listeners/PlayerDeathListener.java
@@ -62,11 +62,11 @@ public final class PlayerDeathListener implements Listener {
         // Handle anti-alt logic first
         if (handleAntiAltLogic(event, player, killer)) return;
 
-        boolean looseHeartsToNature = plugin.getConfig().getBoolean("looseHeartsToNature") || plugin.getConfig().getInt("heartsPerKill") <= 0;
-        boolean looseHeartsToPlayer = plugin.getConfig().getBoolean("looseHeartsToPlayer") || plugin.getConfig().getInt("heartsPerNaturalDeath") <= 0;
+        boolean loseHeartsToNature = plugin.getConfig().getBoolean("looseHeartsToNature") || plugin.getConfig().getInt("heartsPerKill") <= 0;
+        boolean loseHeartsToPlayer = plugin.getConfig().getBoolean("looseHeartsToPlayer") || plugin.getConfig().getInt("heartsPerNaturalDeath") <= 0;
 
         // Natural death or death by player
-        if ((!isDeathByPlayer && looseHeartsToNature) || (isDeathByPlayer && looseHeartsToPlayer)) {
+        if ((!isDeathByPlayer && loseHeartsToNature) || (isDeathByPlayer && loseHeartsToPlayer)) {
             handleHeartLoss(event, player, killer, playerData, isDeathByPlayer);
         }
     }
@@ -76,7 +76,7 @@ public final class PlayerDeathListener implements Listener {
 
         double healthPerKill = plugin.getConfig().getInt("heartsPerKill") * 2;
         double healthPerNaturalDeath = plugin.getConfig().getInt("heartsPerNaturalDeath") * 2;
-        double healthToLoose = isDeathByPlayer ? healthPerKill : healthPerNaturalDeath;
+        double healthTolose = isDeathByPlayer ? healthPerKill : healthPerNaturalDeath;
 
         // Check bypass first (takes priority over grace period)
         boolean victimHasBypass = restrictedHeartLossByBypass(player);
@@ -116,13 +116,13 @@ public final class PlayerDeathListener implements Listener {
 
         if (isDeathByPlayer && !killerInGracePeriod && !killerHasBypass) {
             
-            if (handleHeartGainCooldown(event, player, killer, healthToLoose)) {
+            if (handleHeartGainCooldown(event, player, killer, healthTolose)) {
                 preventKillerGain = true;
                 if (plugin.getConfig().getBoolean("heartGainCooldown.dropOnCooldown")) {
                     droppedAtKiller = true;
                 }
             }
-            if (handleMaxHeartsLimit(event, player, killer, healthToLoose)) {
+            if (handleMaxHeartsLimit(event, player, killer, healthTolose)) {
                 preventKillerGain = true;
                 if (plugin.getConfig().getBoolean("dropHeartsIfMax")) {
                     droppedAtKiller = true;
@@ -130,15 +130,15 @@ public final class PlayerDeathListener implements Listener {
             }
         }
 
-        if (playerData.getMaxHealth() - healthToLoose <= minHearts) {
-            handleElimination(event, player, playerData, killer, isDeathByPlayer, healthToLoose, preventKillerGain, droppedAtKiller);
+        if (playerData.getMaxHealth() - healthTolose <= minHearts) {
+            handleElimination(event, player, playerData, killer, isDeathByPlayer, healthTolose, preventKillerGain, droppedAtKiller);
             return;
         }
 
         if (isDeathByPlayer) {
-            handlePvPDeath(event, player, killer, playerData, healthToLoose, preventKillerGain, droppedAtKiller);
+            handlePvPDeath(event, player, killer, playerData, healthTolose, preventKillerGain, droppedAtKiller);
         } else {
-            handleNaturalDeath(event, player, playerData, healthToLoose);
+            handleNaturalDeath(event, player, playerData, healthTolose);
         }
     }
 
@@ -191,10 +191,10 @@ public final class PlayerDeathListener implements Listener {
         return false;
     }
 
-    private void handlePvPDeath(PlayerDeathEvent event, Player player, Player killer, PlayerData playerData, double healthToLoose, boolean preventKillerGain, boolean droppedAtKiller) {
-        double healthToGain = healthToLoose;
+    private void handlePvPDeath(PlayerDeathEvent event, Player player, Player killer, PlayerData playerData, double healthTolose, boolean preventKillerGain, boolean droppedAtKiller) {
+        double healthToGain = healthTolose;
 
-        ZPlayerPvPDeathEvent pvpEvent = new ZPlayerPvPDeathEvent(event, killer, healthToLoose, healthToGain);
+        ZPlayerPvPDeathEvent pvpEvent = new ZPlayerPvPDeathEvent(event, killer, healthTolose, healthToGain);
 
         boolean shouldDropFromPvP = plugin.getConfig().getBoolean("dropHeartsPlayer") && !droppedAtKiller;
         pvpEvent.setShouldDropHearts(shouldDropFromPvP);
@@ -224,9 +224,9 @@ public final class PlayerDeathListener implements Listener {
         }
     }
 
-    private void handleNaturalDeath(PlayerDeathEvent event, Player player, PlayerData playerData, double healthToLoose) {
+    private void handleNaturalDeath(PlayerDeathEvent event, Player player, PlayerData playerData, double healthTolose) {
         ZPlayerNaturalDeathEvent naturalEvent =
-                new ZPlayerNaturalDeathEvent(event, healthToLoose);
+                new ZPlayerNaturalDeathEvent(event, healthTolose);
         naturalEvent.setShouldDropHearts(plugin.getConfig().getBoolean("dropHeartsNatural"));
         Bukkit.getPluginManager().callEvent(naturalEvent);
 
@@ -250,7 +250,7 @@ public final class PlayerDeathListener implements Listener {
         }
     }
 
-    private void handleElimination(PlayerDeathEvent event, Player player, PlayerData playerData, Player killer, boolean isDeathByPlayer, double healthToLoose, boolean preventKillerGain, boolean droppedAtKiller) {
+    private void handleElimination(PlayerDeathEvent event, Player player, PlayerData playerData, Player killer, boolean isDeathByPlayer, double healthTolose, boolean preventKillerGain, boolean droppedAtKiller) {
         ZPlayerEliminationEvent eliminationEvent =
                 new ZPlayerEliminationEvent(event, killer);
         eliminationEvent.setShouldBanPlayer(!plugin.getConfig().getBoolean("disablePlayerBanOnElimination"));
@@ -292,24 +292,24 @@ public final class PlayerDeathListener implements Listener {
                 if (isDeathByPlayer && killer != null) {
                     boolean dropHeartsPlayer = plugin.getConfig().getBoolean("dropHeartsPlayer", true);
                     if (!preventKillerGain && !droppedAtKiller && !dropHeartsPlayer) {
-                        boolean preventedByCooldown = handleHeartGainCooldown(event, player, killer, healthToLoose);
+                        boolean preventedByCooldown = handleHeartGainCooldown(event, player, killer, healthTolose);
                         boolean preventedByMax = false;
                         if (!preventedByCooldown) {
-                            preventedByMax = handleMaxHeartsLimit(event, player, killer, healthToLoose);
+                            preventedByMax = handleMaxHeartsLimit(event, player, killer, healthTolose);
                         }
                         if (!preventedByCooldown && !preventedByMax) {
-                            handleKillerHeartGainDirect(killer, healthToLoose);
+                            handleKillerHeartGainDirect(killer, healthTolose);
                         }
                     } else {
                         if (droppedAtKiller || dropHeartsPlayer) {
-                            dropHeartsNaturally(killer.getLocation(), (int) (healthToLoose / 2), CustomItemManager.createKillHeart());
+                            dropHeartsNaturally(killer.getLocation(), (int) (healthTolose / 2), CustomItemManager.createKillHeart());
                         }
                     }
                 } else if (!isDeathByPlayer) {
                     // Natural death eliminations also drop hearts if enabled
                     boolean dropHeartsNatural = plugin.getConfig().getBoolean("dropHeartsNatural", true);
                     if (dropHeartsNatural) {
-                        dropHeartsNaturally(player.getLocation(), (int) (healthToLoose / 2), CustomItemManager.createNaturalDeathHeart());
+                        dropHeartsNaturally(player.getLocation(), (int) (healthTolose / 2), CustomItemManager.createNaturalDeathHeart());
                     }
                 }
             }
@@ -410,7 +410,7 @@ public final class PlayerDeathListener implements Listener {
 
     private boolean restrictedHeartLossByGracePeriod(Player player) {
         GracePeriodManager gracePeriodManager = plugin.getGracePeriodManager();
-        return gracePeriodManager.isInGracePeriod(player) && !gracePeriodManager.getConfig().looseHearts();
+        return gracePeriodManager.isInGracePeriod(player) && !gracePeriodManager.getConfig().loseHearts();
     }
 
     private boolean restrictedHeartGainByGracePeriod(Player player) {
@@ -420,7 +420,7 @@ public final class PlayerDeathListener implements Listener {
 
     private boolean restrictedHeartLossByBypass(Player player) {
         BypassManager bypassManager = plugin.getBypassManager();
-        return bypassManager.hasBypass(player) && !bypassManager.getConfig().looseHearts();
+        return bypassManager.hasBypass(player) && !bypassManager.getConfig().loseHearts();
     }
 
     private boolean restrictedHeartGainByBypass(Player player) {

--- a/src/main/java/com/zetaplugins/lifestealz/listeners/PlayerLoginListener.java
+++ b/src/main/java/com/zetaplugins/lifestealz/listeners/PlayerLoginListener.java
@@ -46,8 +46,8 @@ public final class PlayerLoginListener implements Listener {
 
     private boolean shouldKickPlayer(PlayerData playerData) {
         boolean disabledBanOnDeath = plugin.getConfig().getBoolean("disablePlayerBanOnElimination");
-        double minHearts = plugin.getConfig().getInt("minHearts") * 2;
-        return playerData.getMaxHealth() <= minHearts && !disabledBanOnDeath;
+        double minHealth = plugin.getConfig().getInt("minHearts") * 2;
+        return playerData.getMaxHealth() <= minHealth && !disabledBanOnDeath;
     }
 
     private void kickPlayer(PlayerLoginEvent event) {

--- a/src/main/java/com/zetaplugins/lifestealz/util/BypassManager.java
+++ b/src/main/java/com/zetaplugins/lifestealz/util/BypassManager.java
@@ -46,7 +46,7 @@ public final class BypassManager {
             return plugin.getConfig().getBoolean("bypassPermission.useHearts", false);
         }
 
-        public boolean looseHearts() {
+        public boolean loseHearts() {
             return plugin.getConfig().getBoolean("bypassPermission.looseHearts", false);
         }
 

--- a/src/main/java/com/zetaplugins/lifestealz/util/GracePeriodManager.java
+++ b/src/main/java/com/zetaplugins/lifestealz/util/GracePeriodManager.java
@@ -195,7 +195,7 @@ public final class GracePeriodManager {
             return plugin.getConfig().getBoolean("gracePeriod.useHearts");
         }
 
-        public boolean looseHearts() {
+        public boolean loseHearts() {
             return plugin.getConfig().getBoolean("gracePeriod.looseHearts");
         }
 

--- a/src/main/java/com/zetaplugins/lifestealz/util/MaxHeartsManager.java
+++ b/src/main/java/com/zetaplugins/lifestealz/util/MaxHeartsManager.java
@@ -17,21 +17,21 @@ public final class MaxHeartsManager {
      * @return the maximum number of hearts the player can have
      */
     public static double getMaxHearts(Player player, FileConfiguration config) {
-        final double configMaxHearts = config.getInt("maxHearts") * 2;
+        final int configMaxHearts = config.getInt("maxHearts");
 
-        int highestFound = -1;
+        int highestHeartLimit = -1;
 
         for (PermissionAttachmentInfo permInfo : player.getEffectivePermissions()) {
             String perm = permInfo.getPermission();
             if (perm.startsWith("lifestealz.maxhearts.")) {
                 try {
                     String numberPart = perm.substring("lifestealz.maxhearts.".length());
-                    int hearts = Integer.parseInt(numberPart) * 2;
-                    if (hearts > highestFound) highestFound = hearts;
+                    int hearts = Integer.parseInt(numberPart);
+                    if (hearts > highestHeartLimit) highestHeartLimit = hearts;
                 } catch (NumberFormatException ignored) {}
             }
         }
 
-        return highestFound == -1 ? configMaxHearts : highestFound;
+        return highestHeartLimit == -1 ? configMaxHearts : highestHeartLimit;
     }
 }

--- a/src/main/java/com/zetaplugins/lifestealz/util/PapiExpansion.java
+++ b/src/main/java/com/zetaplugins/lifestealz/util/PapiExpansion.java
@@ -72,7 +72,7 @@ public final class PapiExpansion extends PlaceholderExpansion {
                 // Default to max hearts from config if player is not online
                 if (onlinePlayer == null) return String.valueOf(plugin.getConfig().getInt("maxHearts"));
 
-                return String.valueOf((int) (MaxHeartsManager.getMaxHearts(onlinePlayer, plugin.getConfig()) / 2));
+                return String.valueOf((int) MaxHeartsManager.getMaxHearts(onlinePlayer, plugin.getConfig()));
             }
             case "maxrevives": {
                 return String.valueOf(plugin.getConfig().getInt("maxRevives"));

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -210,7 +210,7 @@ antiAlt:
   preventKill: false
   # If a message should be sent to the player, when an alt kill attempt is detected
   sendMessage: false
-  # Add custom comamnds, to be executed when a possible alt kill attempt is detected
+  # Add custom commands, to be executed when a possible alt kill attempt is detected
   # You can use &player& to insert the player name (commands are executed for both players)
   commands:
     # - "say Please don't kill alts"

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -160,7 +160,7 @@ gracePeriod:
   damageToPlayers: false
   # Should a player be able to use hearts during the grace period
   useHearts: false
-  # Should a player be able to loose hearts during the grace period (if set to false, the killer will also not gain a heart)
+  # Should a player be able to lose hearts during the grace period (if set to false, the killer will also not gain a heart)
   looseHearts: false
   # Should a player be able to gain hearts during the grace period
   gainHearts: false


### PR DESCRIPTION
A few places confused "hearts" with "health".
Also fixed a few typos, primarily "loose" and "lose".

Note: The config misspells "lose" on lines 71, 73, 164, and 190.  I didn't fix those misspellings as they would cause breaking changes for anyone using the plugin.  I also didn't change the misspellings of those configs in the README to maintain parity.