### PR TITLE
Preventing heart drops while a player has no armor

### DIFF
--- a/src/main/java/com/zetaplugins/lifestealz/listeners/PlayerDeathListener.java
+++ b/src/main/java/com/zetaplugins/lifestealz/listeners/PlayerDeathListener.java
@@ -66,11 +66,18 @@ public final class PlayerDeathListener implements Listener {
         // Handle anti-alt logic first
         if (handleAntiAltLogic(event, player, killer)) return;
 
-        boolean looseHeartsToNature = plugin.getConfig().getBoolean("looseHeartsToNature") || plugin.getConfig().getInt("heartsPerKill") <= 0;
-        boolean looseHeartsToPlayer = plugin.getConfig().getBoolean("looseHeartsToPlayer") || plugin.getConfig().getInt("heartsPerNaturalDeath") <= 0;
+        boolean loseHeartsToNature = plugin.getConfig().getBoolean("looseHeartsToNature") || plugin.getConfig().getInt("heartsPerKill") <= 0;
+        boolean loseHeartsToPlayer = plugin.getConfig().getBoolean("looseHeartsToPlayer") || plugin.getConfig().getInt("heartsPerNaturalDeath") <= 0;
+        boolean loseHeartsToNatureWhileNaked = plugin.getConfig().getBoolean("loseHeartsToNatureWhileNaked");
+        boolean loseHeartsToPlayerWhileNaked = plugin.getConfig().getBoolean("loseHeartsToPlayerWhileNaked");
 
         // Natural death or death by player
-        if ((!isDeathByPlayer && looseHeartsToNature) || (isDeathByPlayer && looseHeartsToPlayer)) {
+        if ((!isDeathByPlayer && loseHeartsToNature) || (isDeathByPlayer && loseHeartsToPlayer)) {
+            // Check if the player can lose hearts while naked
+            if ((!isDeathByPlayer && loseHeartsToNatureWhileNaked) || (isDeathByPlayer && loseHeartsToPlayerWhileNaked)) {
+                if !(Stream.of(player.getInventory().getArmorContents()).filtet(Objects::nonNull).findAny().isPresent()) return;
+            }
+
             handleHeartLoss(event, player, killer, playerData, isDeathByPlayer);
         }
     }
@@ -80,7 +87,7 @@ public final class PlayerDeathListener implements Listener {
 
         double healthPerKill = plugin.getConfig().getInt("heartsPerKill") * 2;
         double healthPerNaturalDeath = plugin.getConfig().getInt("heartsPerNaturalDeath") * 2;
-        double healthToLoose = isDeathByPlayer ? healthPerKill : healthPerNaturalDeath;
+        double healthTolose = isDeathByPlayer ? healthPerKill : healthPerNaturalDeath;
 
         // Check bypass first (takes priority over grace period)
         boolean victimHasBypass = restrictedHeartLossByBypass(player);
@@ -120,13 +127,13 @@ public final class PlayerDeathListener implements Listener {
 
         if (isDeathByPlayer && !killerInGracePeriod && !killerHasBypass) {
             
-            if (handleHeartGainCooldown(event, player, killer, healthToLoose)) {
+            if (handleHeartGainCooldown(event, player, killer, healthTolose)) {
                 preventKillerGain = true;
                 if (plugin.getConfig().getBoolean("heartGainCooldown.dropOnCooldown")) {
                     droppedAtKiller = true;
                 }
             }
-            if (handleMaxHeartsLimit(event, player, killer, healthToLoose)) {
+            if (handleMaxHeartsLimit(event, player, killer, healthTolose)) {
                 preventKillerGain = true;
                 if (plugin.getConfig().getBoolean("dropHeartsIfMax")) {
                     droppedAtKiller = true;
@@ -134,15 +141,15 @@ public final class PlayerDeathListener implements Listener {
             }
         }
 
-        if (playerData.getMaxHealth() - healthToLoose <= minHearts) {
-            handleElimination(event, player, playerData, killer, isDeathByPlayer, healthToLoose, preventKillerGain, droppedAtKiller);
+        if (playerData.getMaxHealth() - healthTolose <= minHearts) {
+            handleElimination(event, player, playerData, killer, isDeathByPlayer, healthTolose, preventKillerGain, droppedAtKiller);
             return;
         }
 
         if (isDeathByPlayer) {
-            handlePvPDeath(event, player, killer, playerData, healthToLoose, preventKillerGain, droppedAtKiller);
+            handlePvPDeath(event, player, killer, playerData, healthTolose, preventKillerGain, droppedAtKiller);
         } else {
-            handleNaturalDeath(event, player, playerData, healthToLoose);
+            handleNaturalDeath(event, player, playerData, healthTolose);
         }
     }
 
@@ -195,10 +202,10 @@ public final class PlayerDeathListener implements Listener {
         return false;
     }
 
-    private void handlePvPDeath(PlayerDeathEvent event, Player player, Player killer, PlayerData playerData, double healthToLoose, boolean preventKillerGain, boolean droppedAtKiller) {
-        double healthGain = healthToLoose;
+    private void handlePvPDeath(PlayerDeathEvent event, Player player, Player killer, PlayerData playerData, double healthTolose, boolean preventKillerGain, boolean droppedAtKiller) {
+        double healthGain = healthTolose;
 
-        ZPlayerPvPDeathEvent pvpEvent = new ZPlayerPvPDeathEvent(event, killer, healthToLoose, healthGain);
+        ZPlayerPvPDeathEvent pvpEvent = new ZPlayerPvPDeathEvent(event, killer, healthTolose, healthGain);
 
         boolean shouldDropFromPvP = plugin.getConfig().getBoolean("dropHeartsPlayer") && !droppedAtKiller;
         pvpEvent.setShouldDropHearts(shouldDropFromPvP);
@@ -228,9 +235,9 @@ public final class PlayerDeathListener implements Listener {
         }
     }
 
-    private void handleNaturalDeath(PlayerDeathEvent event, Player player, PlayerData playerData, double healthToLoose) {
+    private void handleNaturalDeath(PlayerDeathEvent event, Player player, PlayerData playerData, double healthTolose) {
         ZPlayerNaturalDeathEvent naturalEvent =
-                new ZPlayerNaturalDeathEvent(event, healthToLoose);
+                new ZPlayerNaturalDeathEvent(event, healthTolose);
         naturalEvent.setShouldDropHearts(plugin.getConfig().getBoolean("dropHeartsNatural"));
         Bukkit.getPluginManager().callEvent(naturalEvent);
 
@@ -254,7 +261,7 @@ public final class PlayerDeathListener implements Listener {
         }
     }
 
-    private void handleElimination(PlayerDeathEvent event, Player player, PlayerData playerData, Player killer, boolean isDeathByPlayer, double healthToLoose, boolean preventKillerGain, boolean droppedAtKiller) {
+    private void handleElimination(PlayerDeathEvent event, Player player, PlayerData playerData, Player killer, boolean isDeathByPlayer, double healthTolose, boolean preventKillerGain, boolean droppedAtKiller) {
         ZPlayerEliminationEvent eliminationEvent =
                 new ZPlayerEliminationEvent(event, killer);
         eliminationEvent.setShouldBanPlayer(!plugin.getConfig().getBoolean("disablePlayerBanOnElimination"));
@@ -296,24 +303,24 @@ public final class PlayerDeathListener implements Listener {
                 if (isDeathByPlayer && killer != null) {
                     boolean dropHeartsPlayer = plugin.getConfig().getBoolean("dropHeartsPlayer", true);
                     if (!preventKillerGain && !droppedAtKiller && !dropHeartsPlayer) {
-                        boolean preventedByCooldown = handleHeartGainCooldown(event, player, killer, healthToLoose);
+                        boolean preventedByCooldown = handleHeartGainCooldown(event, player, killer, healthTolose);
                         boolean preventedByMax = false;
                         if (!preventedByCooldown) {
-                            preventedByMax = handleMaxHeartsLimit(event, player, killer, healthToLoose);
+                            preventedByMax = handleMaxHeartsLimit(event, player, killer, healthTolose);
                         }
                         if (!preventedByCooldown && !preventedByMax) {
-                            handleKillerHeartGainDirect(killer, healthToLoose);
+                            handleKillerHeartGainDirect(killer, healthTolose);
                         }
                     } else {
                         if (droppedAtKiller || dropHeartsPlayer) {
-                            dropHeartsNaturally(killer.getLocation(), (int) (healthToLoose / 2), CustomItemManager.createKillHeart());
+                            dropHeartsNaturally(killer.getLocation(), (int) (healthTolose / 2), CustomItemManager.createKillHeart());
                         }
                     }
                 } else if (!isDeathByPlayer) {
                     // Natural death eliminations also drop hearts if enabled
                     boolean dropHeartsNatural = plugin.getConfig().getBoolean("dropHeartsNatural", true);
                     if (dropHeartsNatural) {
-                        dropHeartsNaturally(player.getLocation(), (int) (healthToLoose / 2), CustomItemManager.createNaturalDeathHeart());
+                        dropHeartsNaturally(player.getLocation(), (int) (healthTolose / 2), CustomItemManager.createNaturalDeathHeart());
                     }
                 }
             }
@@ -414,7 +421,7 @@ public final class PlayerDeathListener implements Listener {
 
     private boolean restrictedHeartLossByGracePeriod(Player player) {
         GracePeriodManager gracePeriodManager = plugin.getGracePeriodManager();
-        return gracePeriodManager.isInGracePeriod(player) && !gracePeriodManager.getConfig().looseHearts();
+        return gracePeriodManager.isInGracePeriod(player) && !gracePeriodManager.getConfig().loseHearts();
     }
 
     private boolean restrictedHeartGainByGracePeriod(Player player) {
@@ -424,7 +431,7 @@ public final class PlayerDeathListener implements Listener {
 
     private boolean restrictedHeartLossByBypass(Player player) {
         BypassManager bypassManager = plugin.getBypassManager();
-        return bypassManager.hasBypass(player) && !bypassManager.getConfig().looseHearts();
+        return bypassManager.hasBypass(player) && !bypassManager.getConfig().loseHearts();
     }
 
     private boolean restrictedHeartGainByBypass(Player player) {

--- a/src/main/java/com/zetaplugins/lifestealz/util/BypassManager.java
+++ b/src/main/java/com/zetaplugins/lifestealz/util/BypassManager.java
@@ -46,7 +46,7 @@ public final class BypassManager {
             return plugin.getConfig().getBoolean("bypassPermission.useHearts", false);
         }
 
-        public boolean looseHearts() {
+        public boolean loseHearts() {
             return plugin.getConfig().getBoolean("bypassPermission.looseHearts", false);
         }
 

--- a/src/main/java/com/zetaplugins/lifestealz/util/GracePeriodManager.java
+++ b/src/main/java/com/zetaplugins/lifestealz/util/GracePeriodManager.java
@@ -195,7 +195,7 @@ public final class GracePeriodManager {
             return plugin.getConfig().getBoolean("gracePeriod.useHearts");
         }
 
-        public boolean looseHearts() {
+        public boolean loseHearts() {
             return plugin.getConfig().getBoolean("gracePeriod.looseHearts");
         }
 

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -71,6 +71,10 @@ dropHeartsIfMax: true
 looseHeartsToNature: true
 # If a player should lose a heart, when being killed by another player
 looseHeartsToPlayer: true
+# If a player should lose a heart, when dying to nature (hostile mobs, lava, etc), while the player is naked
+loseHeartsToNatureWhileNaked: true
+# If a player should lose a heart, when being killed by another player, while the player is naked
+loseHeartsToPlayerWhileNaked: true
 # Whether it should be announced, when a player got eliminated (has no more hearts)
 announceElimination: true
 


### PR DESCRIPTION
Added 2 configs to config.yml
1. `loseHeartsToNatureWhileNaked`
2. `loseHeartsToPlayerWhileNaked`

They prevent heart loss while a player has no armor equipped (commonly referred to as being "naked").