### PR TITLE
Fix to prevent healing dead killers when they gain a heart.

### DIFF
--- a/src/main/java/com/zetaplugins/lifestealz/listeners/PlayerDeathListener.java
+++ b/src/main/java/com/zetaplugins/lifestealz/listeners/PlayerDeathListener.java
@@ -352,10 +352,20 @@ public final class PlayerDeathListener implements Listener {
 
     private void handleKillerHeartGainDirect(Player killer, double healthGain) {
         PlayerData killerPlayerData = plugin.getStorage().load(killer.getUniqueId());
-        killerPlayerData.setMaxHealth(killerPlayerData.getMaxHealth() + healthGain);
+
+        // Store max health increase.
+        double newMaxHealth = killerPlayerData.getMaxHealth() + healthGain;
+        killerPlayerData.setMaxHealth(newMaxHealth);
         plugin.getStorage().save(killerPlayerData);
-        LifeStealZ.setMaxHealth(killer, killerPlayerData.getMaxHealth());
-        killer.setHealth(Math.min(killer.getHealth() + healthGain, killerPlayerData.getMaxHealth()));
+
+        // Set max health increase.
+        LifeStealZ.setMaxHealth(killer, newMaxHealth);
+
+        // Heal an alive killer only.
+        if (!killer.isDead() && killer.getHealth() > 0.0) {
+            killer.setHealth(Math.min(killer.getHealth() + healthGain, newMaxHealth));
+        }
+
         CooldownManager.lastHeartGain.put(killer.getUniqueId(), System.currentTimeMillis());
     }
 


### PR DESCRIPTION
Fixed an issue where a killer gaining a heart while dead/dying resulted in a desync between the client and server.

The killer's maximum health and current health were being increased when the heart was rewarded. If the killer and victim died at the same time, the killer was stuck in a desynced state until they rejoined the server.

[A recording of this occurring was posted into the Discord server](https://canary.discord.com/channels/990295419005333554/990297017974665246/1530709061216112671).